### PR TITLE
api(packer): improve packs algorithms and add cache layer

### DIFF
--- a/internal/packer/packer.go
+++ b/internal/packer/packer.go
@@ -13,11 +13,16 @@ import (
 	"github.com/dsha256/packer-pro/internal/entity"
 )
 
-const sortedSizesKeyName = "SortedSizes"
+const sortedSizesKeyName = "SortedSizesCache"
 
-// SortedSizesKey is a Redis key for SortedSizes keyspace.
+// SortedSizesKey is a Redis key for SortedSizesCache keyspace.
 type SortedSizesKey struct {
-	Name string
+	Name string `json:"name"`
+}
+
+// CalculatedSizesKey is a Redis key for CalculatedPacksCache keyspace.
+type CalculatedSizesKey struct {
+	Items int `json:"items"`
 }
 
 var (
@@ -26,9 +31,15 @@ var (
 		EvictionPolicy: cache.AllKeysLRU,
 	})
 
-	// SortedSizes is a Redis Keyspace.
-	SortedSizes = cache.NewListKeyspace[SortedSizesKey, int](Cache, cache.KeyspaceConfig{
+	// SortedSizesCache is a Redis Keyspace.
+	SortedSizesCache = cache.NewListKeyspace[SortedSizesKey, int](Cache, cache.KeyspaceConfig{
 		KeyPattern:    "sortedSizes/:Name",
+		DefaultExpiry: cache.ExpireIn(1 * time.Hour),
+	})
+
+	// CalculatedPacksCache caches already calculated pack sizes based on items.
+	CalculatedPacksCache = cache.NewStructKeyspace[CalculatedSizesKey, GetPacketsResp](Cache, cache.KeyspaceConfig{
+		KeyPattern:    "calculatedPacks/:Items",
 		DefaultExpiry: cache.ExpireIn(1 * time.Hour),
 	})
 

--- a/internal/packer/packer.helpers.go
+++ b/internal/packer/packer.helpers.go
@@ -61,7 +61,7 @@ func refreshSortedSizesCacheFromDB(ctx context.Context, entity *entity.Client) e
 	}
 
 	for _, size := range allSizes {
-		_, err = SortedSizes.PushRight(ctx, sortedSizesKey, size.Size)
+		_, err = SortedSizesCache.PushRight(ctx, sortedSizesKey, size.Size)
 		if err != nil {
 			return err
 		}
@@ -70,9 +70,9 @@ func refreshSortedSizesCacheFromDB(ctx context.Context, entity *entity.Client) e
 	return nil
 }
 
-// cleanUpSortedSizesCache cleans up the redis cluster's keyspace dedicated for SortedSizes.
+// cleanUpSortedSizesCache cleans up the redis cluster's keyspace dedicated for SortedSizesCache.
 func cleanUpSortedSizesCache(ctx context.Context) error {
-	_, err := SortedSizes.Delete(ctx, sortedSizesKey)
+	_, err := SortedSizesCache.Delete(ctx, sortedSizesKey)
 	if err != nil {
 		return err
 	}
@@ -80,10 +80,10 @@ func cleanUpSortedSizesCache(ctx context.Context) error {
 	return nil
 }
 
-// refreshSortedSizesCache ...
+// refreshSortedSizesCache sets new sorted sizes to SortedSizesCache.
 func refreshSortedSizesCache(ctx context.Context, sortedSizes []int) error {
 	for _, size := range sortedSizes {
-		_, err := SortedSizes.PushRight(ctx, sortedSizesKey, size)
+		_, err := SortedSizesCache.PushRight(ctx, sortedSizesKey, size)
 		if err != nil {
 			return err
 		}
@@ -92,6 +92,7 @@ func refreshSortedSizesCache(ctx context.Context, sortedSizes []int) error {
 	return nil
 }
 
+// cleanUpDBSizes deletes all the sizes stored in the DB.
 func cleanUpDBSizes(ctx context.Context, entity *entity.Client) error {
 	_, err := entity.Size.Delete().Where().Exec(ctx)
 	if err == nil {


### PR DESCRIPTION
Optimeze getMinNecessaryPacks time complexity (O Notation) to O(n). Speed up packs calculation by caching calculated packs based on items.